### PR TITLE
Ilia use post type name instead of UUID

### DIFF
--- a/src/neo4j/services/neo4j.seed.service.ts
+++ b/src/neo4j/services/neo4j.seed.service.ts
@@ -47,9 +47,9 @@ export class Neo4jSeedService {
             `CREATE CONSTRAINT openness_opennessId_UNIQUE FOR (openness:${this.opennessLabel}) REQUIRE openness.opennessId IS UNIQUE`,
             {}
         );
-        // PostType - PostType.postTypeId IS UNIQUE
+        // PostType - PostType.postTypeName IS UNIQUE
         await this._neo4jService.tryWriteAsync(
-            `CREATE CONSTRAINT postType_postTypeId_UNIQUE FOR (postType:${this.postTypeLabel}) REQUIRE postType.postTypeId IS UNIQUE`,
+            `CREATE CONSTRAINT postType_postTypeName_UNIQUE FOR (postType:${this.postTypeLabel}) REQUIRE postType.postTypeName IS UNIQUE`,
             {}
         );
         // PostTag - PostTag.tagId IS UNIQUE
@@ -254,7 +254,9 @@ export class Neo4jSeedService {
                     .join(",")}] AS postTagIDsToBeConnected
                 UNWIND postTagIDsToBeConnected as postTagIdToBeConnected
                     MATCH (p1:${this.postLabel}) WHERE p1.postId = $postId
-                    MATCH (postType:${this.postTypeLabel}) WHERE postType.postTypeId = $postTypeId
+                    MATCH (postType:${
+                        this.postTypeLabel
+                    }) WHERE postType.postTypeName = $postTypeName
                     MATCH (postTag:${
                         this.postTagLabel
                     }) WHERE postTag.tagId = postTagIdToBeConnected
@@ -292,7 +294,7 @@ export class Neo4jSeedService {
                     pending: postEntity.pending,
 
                     // PostType
-                    postTypeId: postEntity.postType.postTypeId,
+                    postTypeName: postEntity.postType.postTypeName.trim().toLowerCase(),
 
                     // AuthoredProps
                     authoredProps_authoredAt: authoredProps.authoredAt,
@@ -660,12 +662,10 @@ export class Neo4jSeedService {
     public async getPostTypes(): Promise<PostType[]> {
         return new Array<PostType>(
             new PostType({
-                postTypeId: "95aaf886-064e-44b3-906f-3a7798945b7b",
-                postType: "Queery",
+                postTypeName: "queery",
             }),
             new PostType({
-                postTypeId: "2677fd94-976b-4c81-8165-55edd038c581",
-                postType: "Story",
+                postTypeName: "story",
             })
         );
     }

--- a/src/neo4j/services/neo4j.seed.service.ts
+++ b/src/neo4j/services/neo4j.seed.service.ts
@@ -52,9 +52,9 @@ export class Neo4jSeedService {
             `CREATE CONSTRAINT postType_postTypeName_UNIQUE FOR (postType:${this.postTypeLabel}) REQUIRE postType.postTypeName IS UNIQUE`,
             {}
         );
-        // PostTag - PostTag.tagId IS UNIQUE
+        // PostTag - PostTag.tagName IS UNIQUE
         await this._neo4jService.tryWriteAsync(
-            `CREATE CONSTRAINT postTag_tagId_UNIQUE FOR (postTag:${this.postTagLabel}) REQUIRE postTag.tagId IS UNIQUE`,
+            `CREATE CONSTRAINT postTag_tagName_UNIQUE FOR (postTag:${this.postTagLabel}) REQUIRE postTag.tagName IS UNIQUE`,
             {}
         );
         // Award - Award.awardId IS UNIQUE
@@ -95,7 +95,6 @@ export class Neo4jSeedService {
         for (const postTagEntity of postTags) {
             await this._neo4jService.tryWriteAsync(
                 `CREATE (n:${this.postTagLabel} { 
-                tagId: $tagId,
                 tagName: $tagName,
                 tagColor: $tagColor
              })`,
@@ -250,16 +249,16 @@ export class Neo4jSeedService {
                     anonymously: $authoredProps_anonymously
                  }]-(u)
                 WITH [${postEntity.postTags
-                    .map(pt => `"${pt.tagId}"`)
-                    .join(",")}] AS postTagIDsToBeConnected
-                UNWIND postTagIDsToBeConnected as postTagIdToBeConnected
+                    .map(pt => `"${pt.tagName}"`)
+                    .join(",")}] AS postTagNamesToBeConnected
+                UNWIND postTagNamesToBeConnected as postTagNameToBeConnected
                     MATCH (p1:${this.postLabel}) WHERE p1.postId = $postId
                     MATCH (postType:${
                         this.postTypeLabel
                     }) WHERE postType.postTypeName = $postTypeName
                     MATCH (postTag:${
                         this.postTagLabel
-                    }) WHERE postTag.tagId = postTagIdToBeConnected
+                    }) WHERE postTag.tagName = postTagNameToBeConnected
                         MERGE (p1)-[:${PostToPostTypeRelTypes.HAS_POST_TYPE}]->(postType)
                         MERGE (p1)-[:${PostToPostTagRelTypes.HAS_POST_TAG}]->(postTag)
                 WITH [${postEntity.awards[PostToAwardRelTypes.HAS_AWARD].records
@@ -673,32 +672,26 @@ export class Neo4jSeedService {
     public async getPostTags(): Promise<PostTag[]> {
         return new Array<PostTag>(
             new PostTag({
-                tagId: "79d8aca0-b08d-4910-9629-487567f9ab1c",
                 tagName: "Serious",
                 tagColor: "#FF758C",
             }),
             new PostTag({
-                tagId: "e0e6a19f-b535-4e0e-a14b-28d4e4c9972f",
                 tagName: "Advice",
                 tagColor: "#FF758C",
             }),
             new PostTag({
-                tagId: "86dc09bb-f659-4210-b0e8-d66c7e34fe06",
                 tagName: "Discussion",
                 tagColor: "#FF758C",
             }),
             new PostTag({
-                tagId: "0bdd1de7-33dd-4464-b28b-d299720925d2",
                 tagName: "Trigger",
                 tagColor: "#FF758C",
             }),
             new PostTag({
-                tagId: "22d97b3b-f853-4afa-8274-5c78085c806b",
                 tagName: "General",
                 tagColor: "#FF758C",
             }),
             new PostTag({
-                tagId: "2a598b96-b878-4575-9601-180b3ac135e9",
                 tagName: "Casual",
                 tagColor: "#FF758C",
             })

--- a/src/posts/controllers/postTags.controller.ts
+++ b/src/posts/controllers/postTags.controller.ts
@@ -28,15 +28,6 @@ export class PostTagsController {
         return await this._postTagsRepository.findAll();
     }
 
-    @Get(":tagId")
-    public async getPostTagByTagId(
-        @Param("tagId", new ParseUUIDPipe()) tagId: string
-    ): Promise<PostTag | Error> {
-        const postTag = await this._postTagsRepository.findPostTagByTagId(tagId);
-        if (postTag === undefined) throw new HttpException("PostTag not found", 404);
-        return postTag;
-    }
-
     @Get("/name/:tagName")
     public async getPostTagByTagName(@Param("tagName") tagName: string) {
         const postTag = await this._postTagsRepository.findPostTagByName(tagName);
@@ -51,16 +42,16 @@ export class PostTagsController {
     //     return createdPostTag;
     // }
 
-    // @Put(":tagId")
+    // @Put(":tagName")
     // @UseGuards(AuthGuard("jwt"))
     // public async updatePostTag(@Body() postTag: PostTag): Promise<void | Error> {
     //     await this._postTagsRepository.updatePostTag(postTag);
     // }
 
-    // @Delete(":tagId")
+    // @Delete(":tagName")
     // public async deletePostTag(
-    //     @Param("tagId", new ParseUUIDPipe()) tagId: string
+    //     @Param("tagName") tagName: string
     // ): Promise<void | Error> {
-    //     await this._postTagsRepository.deletePostTag(tagId);
+    //     await this._postTagsRepository.deletePostTag(tagName);
     // }
 }

--- a/src/posts/controllers/postTypes.controller.ts
+++ b/src/posts/controllers/postTypes.controller.ts
@@ -1,0 +1,33 @@
+import { ApiTags } from "@nestjs/swagger";
+import {
+    ClassSerializerInterceptor,
+    Controller,
+    Get,
+    Inject,
+    Param,
+    UseInterceptors,
+} from "@nestjs/common";
+import { _$ } from "../../_domain/injectableTokens";
+import { DatabaseContext } from "../../database-access-layer/databaseContext";
+import { PostType } from "../models";
+
+@ApiTags("postTypes")
+@Controller("postTypes")
+@UseInterceptors(ClassSerializerInterceptor)
+export class PostTypesController {
+    private readonly _dbContext: DatabaseContext;
+
+    constructor(@Inject(_$.IDatabaseContext) dbContext: DatabaseContext) {
+        this._dbContext = dbContext;
+    }
+
+    @Get()
+    public async index(): Promise<PostType[] | Error> {
+        return await this._dbContext.PostTypes.findAll();
+    }
+
+    @Get(":postTypeName")
+    public async getPostTypeByName(@Param("postTypeName") postTypeName: string) {
+        this._dbContext.PostTypes;
+    }
+}

--- a/src/posts/controllers/postTypes.controller.ts
+++ b/src/posts/controllers/postTypes.controller.ts
@@ -3,6 +3,7 @@ import {
     ClassSerializerInterceptor,
     Controller,
     Get,
+    HttpException,
     Inject,
     Param,
     UseInterceptors,
@@ -28,6 +29,8 @@ export class PostTypesController {
 
     @Get(":postTypeName")
     public async getPostTypeByName(@Param("postTypeName") postTypeName: string) {
-        this._dbContext.PostTypes;
+        const postType = await this._dbContext.PostTypes.findPostTypeByName(postTypeName);
+        if (postType === undefined) throw new HttpException("PostType not found", 404);
+        return postType;
     }
 }

--- a/src/posts/controllers/posts.controller.ts
+++ b/src/posts/controllers/posts.controller.ts
@@ -12,8 +12,6 @@ import {
     UseInterceptors,
     CacheInterceptor,
     CacheTTL,
-    CacheKey,
-    CACHE_MANAGER,
 } from "@nestjs/common";
 import { Post as PostModel } from "../models";
 import { _$ } from "../../_domain/injectableTokens";
@@ -22,7 +20,6 @@ import { PostCreationPayloadDto } from "../models/postCreationPayload.dto";
 import { AuthGuard } from "@nestjs/passport";
 import { IPostsService } from "../services/posts.service.interface";
 import { DatabaseContext } from "../../database-access-layer/databaseContext";
-import { Cache } from "cache-manager";
 
 @ApiTags("posts")
 @Controller("posts")
@@ -34,15 +31,13 @@ export class PostsController {
 
     constructor(
         @Inject(_$.IDatabaseContext) dbContext: DatabaseContext,
-        @Inject(_$.IPostsService) postsService: IPostsService,
-        @Inject(CACHE_MANAGER) private cacheManager: Cache
+        @Inject(_$.IPostsService) postsService: IPostsService
     ) {
         this._dbContext = dbContext;
         this._postsService = postsService;
     }
 
     @Get()
-    @CacheKey("allPosts")
     @CacheTTL(10)
     @UseInterceptors(CacheInterceptor)
     public async index(): Promise<PostModel[] | Error> {

--- a/src/posts/models/post.spec.ts
+++ b/src/posts/models/post.spec.ts
@@ -137,8 +137,7 @@ describe("Post Model Unit Test", () => {
             it("should return an object with proper properties", async () => {
                 const postType = await post.getPostType();
                 expect(typeof postType).toBe("object");
-                expect(postType).toHaveProperty("postTypeId");
-                expect(postType).toHaveProperty("postType");
+                expect(postType).toHaveProperty("postTypeName");
             });
         });
 

--- a/src/posts/models/post.spec.ts
+++ b/src/posts/models/post.spec.ts
@@ -151,7 +151,6 @@ describe("Post Model Unit Test", () => {
                 expect(Array.isArray(postTags)).toBe(true);
                 postTags.forEach(postTag => {
                     expect(typeof postTag).toBe("object");
-                    expect(postTag).toHaveProperty("tagId");
                     expect(postTag).toHaveProperty("tagName");
                 });
             });

--- a/src/posts/models/postCreationPayload.dto.ts
+++ b/src/posts/models/postCreationPayload.dto.ts
@@ -12,10 +12,10 @@ export class PostCreationPayloadDto {
     @IsNotEmpty()
     postContent: string;
 
-    @ApiProperty({ type: String, format: "uuid" })
+    @ApiProperty({ type: String })
     @IsString()
     @IsNotEmpty()
-    postTypeId: string;
+    postTypeName: string;
 
     @ApiProperty({ type: String, format: "uuid", isArray: true })
     @IsArray()

--- a/src/posts/models/postCreationPayload.dto.ts
+++ b/src/posts/models/postCreationPayload.dto.ts
@@ -17,9 +17,9 @@ export class PostCreationPayloadDto {
     @IsNotEmpty()
     postTypeName: string;
 
-    @ApiProperty({ type: String, format: "uuid", isArray: true })
+    @ApiProperty({ type: String, isArray: true })
     @IsArray()
-    postTagIds: string[];
+    postTagNames: string[];
 
     @ApiProperty({ type: Boolean })
     @IsBoolean()

--- a/src/posts/models/postTag.ts
+++ b/src/posts/models/postTag.ts
@@ -3,10 +3,6 @@ import { Labels, NodeProperty } from "../../neo4j/neo4j.decorators";
 
 @Labels("PostTag")
 export class PostTag {
-    @ApiProperty({ type: String, format: "uuid" })
-    @NodeProperty()
-    tagId: string;
-
     @ApiProperty({ type: String })
     @NodeProperty()
     tagName: string;

--- a/src/posts/models/postType.ts
+++ b/src/posts/models/postType.ts
@@ -3,13 +3,9 @@ import { Labels, NodeProperty } from "../../neo4j/neo4j.decorators";
 
 @Labels("PostType")
 export class PostType {
-    @ApiProperty({ type: String, format: "uuid" })
-    @NodeProperty()
-    postTypeId: string;
-
     @ApiProperty({ type: String })
     @NodeProperty()
-    postType: string;
+    postTypeName: string;
 
     constructor(partial?: Partial<PostType>) {
         Object.assign(this, partial);

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -11,6 +11,7 @@ import { PostsService } from "./services/posts.service";
 import { PostTagsRepository } from "./services/postTagRepository/postTags.repository";
 import { PostTypesRepository } from "./services/postTypeRepository/postTypes.repository";
 import { PostAwardRepository } from "./services/postAwardRepository/postAward.repository";
+import { PostTypesController } from "./controllers/postTypes.controller";
 
 @Module({
     imports: [forwardRef(() => DatabaseAccessLayerModule), HttpModule],
@@ -74,6 +75,6 @@ import { PostAwardRepository } from "./services/postAwardRepository/postAward.re
             useClass: PostAwardRepository,
         },
     ],
-    controllers: [PostsController, PostTagsController],
+    controllers: [PostsController, PostTagsController, PostTypesController],
 })
 export class PostsModule {}

--- a/src/posts/services/postRepository/posts.repository.ts
+++ b/src/posts/services/postRepository/posts.repository.ts
@@ -65,12 +65,12 @@ export class PostsRepository implements IPostsRepository {
                     anonymously: $authoredProps_anonymously
                  }]-(u)
                 WITH [${post.postTags
-                    .map(pt => `"${pt.tagId}"`)
-                    .join(",")}] AS postTagIDsToBeConnected
-                UNWIND postTagIDsToBeConnected as postTagIdToBeConnected
+                    .map(pt => `"${pt.tagName}"`)
+                    .join(",")}] AS postTagNamesToBeConnected
+                UNWIND postTagNamesToBeConnected as postTagNameToBeConnected
                     MATCH (p1:Post) WHERE p1.postId = $postId
                     MATCH (postType:PostType) WHERE postType.postTypeName = $postTypeName
-                    MATCH (postTag:PostTag) WHERE postTag.tagId = postTagIdToBeConnected
+                    MATCH (postTag:PostTag) WHERE postTag.tagName = postTagNameToBeConnected
                         MERGE (p1)-[:${PostToPostTypeRelTypes.HAS_POST_TYPE}]->(postType)
                         MERGE (p1)-[:${PostToPostTagRelTypes.HAS_POST_TAG}]->(postTag)
             `,

--- a/src/posts/services/postRepository/posts.repository.ts
+++ b/src/posts/services/postRepository/posts.repository.ts
@@ -69,7 +69,7 @@ export class PostsRepository implements IPostsRepository {
                     .join(",")}] AS postTagIDsToBeConnected
                 UNWIND postTagIDsToBeConnected as postTagIdToBeConnected
                     MATCH (p1:Post) WHERE p1.postId = $postId
-                    MATCH (postType:PostType) WHERE postType.postTypeId = $postTypeId
+                    MATCH (postType:PostType) WHERE postType.postTypeName = $postTypeName
                     MATCH (postTag:PostTag) WHERE postTag.tagId = postTagIdToBeConnected
                         MERGE (p1)-[:${PostToPostTypeRelTypes.HAS_POST_TYPE}]->(postType)
                         MERGE (p1)-[:${PostToPostTagRelTypes.HAS_POST_TAG}]->(postTag)
@@ -86,7 +86,7 @@ export class PostsRepository implements IPostsRepository {
                 pending: post.pending,
 
                 // PostType
-                postTypeId: post.postType.postTypeId,
+                postTypeName: post.postType.postTypeName,
 
                 // AuthoredProps
                 authoredProps_authoredAt: authoredProps.authoredAt ?? new Date().getTime(),

--- a/src/posts/services/postTagRepository/postTags.repository.interface.ts
+++ b/src/posts/services/postTagRepository/postTags.repository.interface.ts
@@ -3,8 +3,6 @@ import { PostTag } from "../../models";
 export interface IPostTagsRepository {
     findAll(): Promise<PostTag[]>;
 
-    findPostTagByTagId(tagId: string): Promise<PostTag | undefined>;
-
     findPostTagByName(tagName: string): Promise<PostTag | undefined>;
 
     addPostTag(postTag: PostTag): Promise<PostTag>;

--- a/src/posts/services/postTagRepository/postTags.repository.spec.ts
+++ b/src/posts/services/postTagRepository/postTags.repository.spec.ts
@@ -77,29 +77,29 @@ describe("PostTagsRepository", () => {
         });
     });
 
-    describe(".getPostTagByTagId()", () => {
-        let postTag: PostTag;
-
-        beforeAll(async () => {
-            postTag = await postTagsRepository.findPostTagByTagId(
-                "59c4221f-f2bb-4a0c-afb4-cc239228ff22"
-            );
-        });
-
-        it("should return a PostTag object", () => {
-            expect(postTag).toBeInstanceOf(PostTag);
-        });
-
-        it("should return the gay tag", () => {
-            expect(postTag.tagName).toEqual("Gay");
-        });
-
-        it("should return a PostTag object with the correct properties", () => {
-            const restrictedProps = new RestrictedProps();
-            const postTypeProps = Object.keys(postTag);
-            const restrictedPropsKeys = Object.keys(restrictedProps);
-
-            expect(postTypeProps).toEqual(expect.arrayContaining(restrictedPropsKeys));
-        });
-    });
+    // describe(".getPostTagByTagId()", () => {
+    //     let postTag: PostTag;
+    //
+    //     beforeAll(async () => {
+    //         postTag = await postTagsRepository.findPostTagByTagId(
+    //             "59c4221f-f2bb-4a0c-afb4-cc239228ff22"
+    //         );
+    //     });
+    //
+    //     it("should return a PostTag object", () => {
+    //         expect(postTag).toBeInstanceOf(PostTag);
+    //     });
+    //
+    //     it("should return the gay tag", () => {
+    //         expect(postTag.tagName).toEqual("Gay");
+    //     });
+    //
+    //     it("should return a PostTag object with the correct properties", () => {
+    //         const restrictedProps = new RestrictedProps();
+    //         const postTypeProps = Object.keys(postTag);
+    //         const restrictedPropsKeys = Object.keys(restrictedProps);
+    //
+    //         expect(postTypeProps).toEqual(expect.arrayContaining(restrictedPropsKeys));
+    //     });
+    // });
 });

--- a/src/posts/services/postTagRepository/postTags.repository.ts
+++ b/src/posts/services/postTagRepository/postTags.repository.ts
@@ -15,15 +15,6 @@ export class PostTagsRepository implements IPostTagsRepository {
         return records.map(record => new PostTag(record.get("t").properties));
     }
 
-    public async findPostTagByTagId(tagId: string): Promise<PostTag | undefined> {
-        const postTag = await this._neo4jService.read(
-            `MATCH (t:PostTag) WHERE t.tagId = $tagId RETURN t`,
-            { tagId: tagId }
-        );
-        if (postTag.records.length === 0) return undefined;
-        return new PostTag(postTag.records[0].get("t").properties);
-    }
-
     public async findPostTagByName(tagName: string): Promise<PostTag | undefined> {
         const queryResult = await this._neo4jService.tryReadAsync(
             `MATCH (t:PostTag) WHERE t.tagName = $tagName RETURN t`,
@@ -34,56 +25,43 @@ export class PostTagsRepository implements IPostTagsRepository {
     }
 
     public async addPostTag(postTag: PostTag): Promise<PostTag> {
-        const tagId = uuidv4();
         await this._neo4jService.tryWriteAsync(
             `
             CREATE (t:PostTag {
-                tagId: $tagId,
                 tagName: $tagName,
                 tagColor: $tagColor
             })
         `,
             {
-                // PostTag
-                tagId: postTag.tagId ?? tagId,
-
-                tagName: postTag.tagName,
-
+                tagName: postTag.tagName.trim().toLowerCase(),
                 tagColor: postTag.tagColor,
             }
         );
 
-        return await this.findPostTagByTagId(postTag.tagId ?? tagId);
+        return await this.findPostTagByName(postTag.tagName);
     }
 
     public async updatePostTag(postTag: PostTag): Promise<void> {
         await this._neo4jService.tryWriteAsync(
             `
-            MATCH (t:PostTag) WHERE t.tagId = $tagId
+            MATCH (t:PostTag) WHERE t.tagName = $tagName
             SET t.tagName = $tagName,
                 t.tagColor = $tagColor
         `,
             {
-                // PostTag
-                tagId: postTag.tagId,
-
-                tagName: postTag.tagName,
-
+                tagName: postTag.tagName.trim().toLowerCase(),
                 tagColor: postTag.tagColor,
             }
         );
     }
 
-    public async deletePostTag(tagId: string): Promise<void> {
+    public async deletePostTag(tagName: string): Promise<void> {
         await this._neo4jService.tryWriteAsync(
             `
-            MATCH (t:PostTag) WHERE t.tagId = $tagId
+            MATCH (t:PostTag) WHERE t.tagName = $tagName
             DETACH DELETE t
         `,
-            {
-                // PostTag
-                tagId: tagId,
-            }
+            { tagName: tagName.trim().toLowerCase() }
         );
     }
 }

--- a/src/posts/services/postTypeRepository/postTypes.repository.interface.ts
+++ b/src/posts/services/postTypeRepository/postTypes.repository.interface.ts
@@ -4,4 +4,6 @@ export interface IPostTypesRepository {
     findAll(): Promise<PostType[]>;
 
     findPostTypeById(postTypeId: string): Promise<PostType | undefined>;
+
+    findPostTypeByName(postTypeName: string): Promise<PostType | undefined>;
 }

--- a/src/posts/services/postTypeRepository/postTypes.repository.spec.ts
+++ b/src/posts/services/postTypeRepository/postTypes.repository.spec.ts
@@ -81,14 +81,12 @@ describe("PostTypesRepository", () => {
         let postType: PostType | undefined;
 
         beforeAll(async () => {
-            postType = await postTypesRepository.findPostTypeById(
-                "2677fd94-976b-4c81-8165-55edd038c581"
-            );
+            postType = await postTypesRepository.findPostTypeByName("story");
         });
 
         it("should return the story post type", () => {
             expect(postType).toBeInstanceOf(PostType);
-            expect(postType?.postType).toBe("Story");
+            expect(postType?.postTypeName).toBe("story");
         });
 
         it("should return a PostType object", () => {
@@ -96,11 +94,12 @@ describe("PostTypesRepository", () => {
         });
 
         it("should return a PostType object with the correct properties", () => {
-            const restrictedProps = new RestrictedProps();
             const postTypeProps = Object.keys(postType);
-            const restrictedPropsKeys = Object.keys(restrictedProps);
+            const correctProps = ["postTypeName"];
 
-            expect(postTypeProps).toEqual(expect.arrayContaining(restrictedPropsKeys));
+            correctProps.forEach(prop => {
+                expect(postTypeProps).toContain(prop);
+            });
         });
     });
 });

--- a/src/posts/services/postTypeRepository/postTypes.repository.ts
+++ b/src/posts/services/postTypeRepository/postTypes.repository.ts
@@ -22,4 +22,16 @@ export class PostTypesRepository implements IPostTypesRepository {
         if (postType.records.length === 0) return undefined;
         return new PostType(postType.records[0].get("t").properties);
     }
+
+    public async findPostTypeByName(postTypeName: string): Promise<PostType | undefined> {
+        const postType = await this._neo4jService.tryReadAsync(
+            `MATCH (pt:PostType) WHERE pt.postTypeName = $postTypeName RETURN pt`,
+            {
+                postTypeName: postTypeName.trim().toLowerCase(),
+            }
+        );
+
+        if (postType.records.length === 0) return undefined;
+        return new PostType(postType.records[0].get("pt").properties);
+    }
 }

--- a/src/posts/services/posts.service.ts
+++ b/src/posts/services/posts.service.ts
@@ -44,7 +44,9 @@ export class PostsService implements IPostsService {
     public async authorNewPost(postPayload: PostCreationPayloadDto): Promise<Post> {
         const user = this.getUserFromRequest();
         // validate the post payload
-        const postType = await this._dbContext.PostTypes.findPostTypeById(postPayload.postTypeId);
+        const postType = await this._dbContext.PostTypes.findPostTypeByName(
+            postPayload.postTypeName
+        );
         if (postType === undefined) throw new HttpException("Post type not found", 404);
 
         const postTags = new Array<PostTag>(postPayload.postTagIds.length);
@@ -149,7 +151,7 @@ export class PostsService implements IPostsService {
             if (allPosts[i].restrictedProps !== null) continue;
 
             await allPosts[i].getPostType();
-            if (allPosts[i].postType.postType === "Queery") {
+            if (allPosts[i].postType.postTypeName === "Queery") {
                 queeryPosts.push(allPosts[i]);
             }
         }

--- a/src/posts/services/posts.service.ts
+++ b/src/posts/services/posts.service.ts
@@ -49,12 +49,12 @@ export class PostsService implements IPostsService {
         );
         if (postType === undefined) throw new HttpException("Post type not found", 404);
 
-        const postTags = new Array<PostTag>(postPayload.postTagIds.length);
-        for (const i in postPayload.postTagIds) {
-            const postTagId = postPayload.postTagIds[i];
-            const foundPostTag = await this._dbContext.PostTags.findPostTagByTagId(postTagId);
+        const postTags = new Array<PostTag>(postPayload.postTagNames.length);
+        for (const i in postPayload.postTagNames) {
+            const postTagName = postPayload.postTagNames[i];
+            const foundPostTag = await this._dbContext.PostTags.findPostTagByName(postTagName);
             if (foundPostTag === undefined)
-                throw new HttpException("Post tag not found: " + postTagId, 404);
+                throw new HttpException("Post tag not found: " + postTagName, 404);
 
             postTags[i] = foundPostTag;
         }


### PR DESCRIPTION
* refactor postTag. removed `postTag.tagId` 
* refactor postType. remoed `postType.postType` and `postType.postTypeId` 
* refactor unique constants of both `postTag` and `postType` from id to name.
* refactor these properties directly in the neo4j database (cloud).
* removed unnecessary controller methods that worked with postTag and postType UUIDs.