### PR TITLE
Better ban hierarchy

### DIFF
--- a/src/moderation/controllers/moderation.controller.ts
+++ b/src/moderation/controllers/moderation.controller.ts
@@ -38,7 +38,7 @@ export class ModerationController {
     }
 
     @Patch("/post/:postId/allow")
-    @Roles(Role.MODERATOR)
+    @Roles(Role.MODERATOR, Role.ADMIN)
     @UseGuards(AuthGuard("jwt"), RolesGuard)
     public async allowPost(@Param("postId", ParseUUIDPipe) postId: UUID): Promise<void> {
         await this._moderationActionsService.allowPost(postId);

--- a/src/moderation/controllers/moderation.controller.ts
+++ b/src/moderation/controllers/moderation.controller.ts
@@ -38,7 +38,7 @@ export class ModerationController {
     }
 
     @Patch("/post/:postId/allow")
-    @Roles(Role.MODERATOR, Role.ADMIN)
+    @Roles(Role.MODERATOR)
     @UseGuards(AuthGuard("jwt"), RolesGuard)
     public async allowPost(@Param("postId", ParseUUIDPipe) postId: UUID): Promise<void> {
         await this._moderationActionsService.allowPost(postId);

--- a/src/users/models/role.ts
+++ b/src/users/models/role.ts
@@ -1,5 +1,5 @@
 export enum Role {
     USER,
-    ADMIN,
     MODERATOR,
+    ADMIN,
 }


### PR DESCRIPTION
- Re-ordered the role model to be relative to permissions.
- Admins can now ban Moderators, but Admins can't ban admins. Moderators can ban users, but Moderators can't ban Moderators or Admins. 
- **Do not merge this PR until the user's roles in the database are updated**